### PR TITLE
Add rows and cols attributes to textarea

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -5246,6 +5246,18 @@
             },
             {
               "kind": "field",
+              "name": "rows",
+              "default": "undefined",
+              "attribute": "rows"
+            },
+            {
+              "kind": "field",
+              "name": "cols",
+              "default": "undefined",
+              "attribute": "cols"
+            },
+            {
+              "kind": "field",
               "name": "name",
               "default": "undefined",
               "attribute": "name"

--- a/dev/vscode-textarea.html
+++ b/dev/vscode-textarea.html
@@ -19,6 +19,8 @@
               value="a\nsdad"
               spellcheck="false"
               id="textarea"
+              rows="10"
+              cols="40"
             ></vscode-textarea>
           </component-preview>
           <script type="module">

--- a/src/vscode-textarea.ts
+++ b/src/vscode-textarea.ts
@@ -29,6 +29,12 @@ export class VscodeTextarea extends VscElement {
   minlength = undefined;
 
   @property()
+  rows = undefined;
+
+  @property()
+  cols = undefined;
+
+  @property()
   name = undefined;
 
   @property()
@@ -115,7 +121,6 @@ export class VscodeTextarea extends VscElement {
           );
           font-size: var(--vscode-font-size, 13px);
           font-weight: var(--vscode-font-weight, normal);
-          width: 100%;
         }
 
         textarea.monospace {
@@ -171,6 +176,8 @@ export class VscodeTextarea extends VscElement {
         })}
         maxlength=${ifDefined(this.maxlength)}
         minlength=${ifDefined(this.minlength)}
+        rows=${ifDefined(this.rows)}
+        cols=${ifDefined(this.cols)}
         name=${ifDefined(this.name)}
         placeholder=${ifDefined(this.placeholder)}
         ?readonly=${this.readonly}


### PR DESCRIPTION
This PR adds new attributes `rows` and `cols` to the `textarea` element, so the user can specify the dimensions of the area displayed.

These attributes are available in https://github.com/microsoft/vscode-webview-ui-toolkit, but was missing in this framework. I think having these attributes here also makes this framework more complete.

I'm a newbie to webview framework coding, so it's quite possible that I have missed something...